### PR TITLE
Scale Simplified AdEMAMix LR

### DIFF
--- a/adv_optm/__init__.py
+++ b/adv_optm/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
     "SignSGD_adv",
 ]
 
-__version__ = "2.2.0"
+__version__ = "2.2.2"

--- a/adv_optm/optim/Adopt_adv.py
+++ b/adv_optm/optim/Adopt_adv.py
@@ -7,7 +7,7 @@ from ..util import param_update
 from ..util.factorization_util import _get_effective_shape, _reconstruct_state, _factorize_state, _nnmf
 from ..util.OrthoGrad import _orthogonalize_gradient
 from ..util.Kourkoutas import KourkoutasHelper
-from ..util.update_util import _grams_update, _cautious_update
+from ..util.update_util import _grams_update, _cautious_update, _scale_sim_AdEMAMix_update
 
 A = 4 / math.pi
 
@@ -279,6 +279,8 @@ class Adopt_adv(torch.optim.Optimizer):
             lr = group['lr']
             step_param_fn = self._step_parameter
 
+        if self.Simplified_AdEMAMix:
+            lr = _scale_sim_AdEMAMix_update(beta1, state['step'] + 1, group["alpha_grad"], lr)
 
         step_param_fn(p, grad, state, group, lr, beta1, beta2, random_int_tensor)
 

--- a/adv_optm/optim/Prodigy_adv.py
+++ b/adv_optm/optim/Prodigy_adv.py
@@ -9,7 +9,7 @@ from ..util import param_update
 from ..util.OrthoGrad import _orthogonalize_gradient
 from ..util.Kourkoutas import KourkoutasHelper
 from ..util.factorization_util import _get_effective_shape, _reconstruct_state, _factorize_state
-from ..util.update_util import _grams_update, _cautious_update
+from ..util.update_util import _grams_update, _cautious_update, _scale_sim_AdEMAMix_update
 
 A = 4 / math.pi
 
@@ -348,6 +348,9 @@ class Prodigy_adv(torch.optim.Optimizer):
         else:
             d = group['d']
             step_param_fn = self._step_parameter
+
+        if self.Simplified_AdEMAMix:
+            dlr = _scale_sim_AdEMAMix_update(self.beta1, state['step'] + 1, group["alpha_grad"], dlr)
 
         step_param_fn(p, grad, state, group, beta2, d, dlr, random_int_tensor)
 

--- a/adv_optm/optim/Simplified_AdEMAMix.py
+++ b/adv_optm/optim/Simplified_AdEMAMix.py
@@ -7,6 +7,7 @@ from ..util import param_update
 from ..util.OrthoGrad import _orthogonalize_gradient
 from ..util.Kourkoutas import KourkoutasHelper
 from ..util.factorization_util import _get_effective_shape, _reconstruct_state, _factorize_state
+from ..util.update_util import _scale_sim_AdEMAMix_update
 
 # A little helper from the original simplified_AdEMAMix
 def linear_hl_warmup_scheduler(step, beta_end, beta_start=0, warmup=1):
@@ -236,6 +237,8 @@ class Simplified_AdEMAMix(torch.optim.Optimizer):
         sqrt_den_num = math.sqrt(state['den_sum'] / state['num_sum'])
 
         lr = group["lr"]
+
+        lr = _scale_sim_AdEMAMix_update(beta1, state['step'] + 1, group["alpha_grad"], lr)
 
         random_int_tensor = None
 

--- a/adv_optm/util/update_util.py
+++ b/adv_optm/util/update_util.py
@@ -22,3 +22,9 @@ def _cautious_update(mt: torch.Tensor, grad: torch.Tensor, inplace: bool=False):
         update_mt = mt.mul(mask)
     del mask
     return update_mt
+
+def _scale_sim_AdEMAMix_update(beta: float, current_step: int, alpha_grad: float, lr: float):
+    momentum_scale = (1 - beta ** current_step) / (1 - beta)
+    total_scale = 1 / (momentum_scale + alpha_grad)
+    lr = lr * total_scale
+    return lr

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="adv_optm",
-    version="2.2.0",
+    version="2.2.2",
     author="Koratahiu",
     author_email="hiuhonor@gmail.com",
     license='Apache 2.0',


### PR DESCRIPTION
Apply a simple scaling rule to ensure `Simplified AdEMAMix` has the same LR/WD as normal AdamW:
```
momentum_scale = (1 - beta ** current_step) / (1 - beta)
total_scale = 1 / (momentum_scale + alpha_grad)
lr = lr * total_scale
```

Tested and worked flawlessly
The only downside is that old backups have to either not upgrade the pkg or adjust their LR 