### PR TITLE
Compile optimizer per-shape

### DIFF
--- a/adv_optm/__init__.py
+++ b/adv_optm/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "SinkSGD_adv",
 ]
 
-__version__ = "2.5.8"
+__version__ = "2.5.9"

--- a/adv_optm/optim/AdaMuon_adv.py
+++ b/adv_optm/optim/AdaMuon_adv.py
@@ -282,11 +282,9 @@ class AdaMuon_adv(torch.optim.Optimizer):
             for device in devices:
                 param_update.set_seed(device)
 
-        # Initialize compiled function
-        self._compiled_muon_step_parameter = None
-        self._compiled_adam_step_parameter = None
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled functions (by parameter shape)
+        self._compiled_muon_step_fns = {}
+        self._compiled_adam_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         """
@@ -444,8 +442,16 @@ class AdaMuon_adv(torch.optim.Optimizer):
             random_int_state_tensor = None
             if is_compiled:
                 step_size = torch.as_tensor(step_size)
-                adam_step_param = self._compiled_adam_step_parameter
-                
+                # Cache compiled function per-shape
+                cache_key = (p.shape, state.get('factored', False))
+                if cache_key not in self._compiled_adam_step_fns:
+                    self._compiled_adam_step_fns[cache_key] = torch.compile(
+                        Muon_AuxAdam._adam_step_parameter,
+                        fullgraph=True,
+                        dynamic=False
+                    )
+                adam_step_param = self._compiled_adam_step_fns[cache_key]
+
                 # Generate state SR random tensor when compiled
                 actual_precision = group.get('adam_actual_state_precision', 'auto')
                 random_int_state_tensor = random_int_tensor
@@ -464,7 +470,15 @@ class AdaMuon_adv(torch.optim.Optimizer):
             random_G_sketch = None
             if is_compiled:
                 lr = torch.as_tensor(group['lr'])
-                muon_step_param = self._compiled_muon_step_parameter
+                # Cache compiled function per-shape
+                cache_key = (p.shape, state.get('factored', False))
+                if cache_key not in self._compiled_muon_step_fns:
+                    self._compiled_muon_step_fns[cache_key] = torch.compile(
+                        self._muon_step_parameter,
+                        fullgraph=True,
+                        dynamic=False
+                    )
+                muon_step_param = self._compiled_muon_step_fns[cache_key]
 
                 # Generate state SR random tensor when compiled
                 actual_precision = group['actual_state_precision']
@@ -481,10 +495,6 @@ class AdaMuon_adv(torch.optim.Optimizer):
                 muon_step_param = self._muon_step_parameter
 
             muon_step_param(p, grad, state, group, lr, random_int_tensor, random_int_state_tensor, random_G_sketch)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_muon_step_parameter = torch.compile(self._muon_step_parameter, *args, **kwargs)
-        self._compiled_adam_step_parameter = torch.compile(Muon_AuxAdam._adam_step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def _muon_step_parameter(self, p, grad, state, group, lr, random_int_tensor, random_int_state_tensor, random_G_sketch):

--- a/adv_optm/optim/AdaMuon_adv.py
+++ b/adv_optm/optim/AdaMuon_adv.py
@@ -541,8 +541,9 @@ class AdaMuon_adv(torch.optim.Optimizer):
             else:
                 update = mt_buf.clone()
 
-            # Factorize
-            state['mu_mbuf_nmf'], state['mv_mbuf_nmf'], state['sign_buf'] = _factorize_state(mt_buf, signed=True, shifter=state['shifter'])
+            # Compress new momentum and store factors
+            for key, val in zip(('mu_mbuf_nmf', 'mv_mbuf_nmf', 'sign_buf'), _factorize_state(mt_buf, signed=True, shifter=state['shifter'])):
+                state[key].copy_(val)
             del mt_buf
 
             # Apply update projection
@@ -569,7 +570,8 @@ class AdaMuon_adv(torch.optim.Optimizer):
                 vt_buf = _reconstruct_state((state['mu_vbuf_nmf'], state['mv_vbuf_nmf']), signed=False, shifter=state['shifter'])
                 # Update second momentum in full-size
                 vt_buf.mul_(beta2).addcmul_(update, update, value=1 - beta2)
-                state['mu_vbuf_nmf'], state['mv_vbuf_nmf'] = _factorize_state(vt_buf, signed=False, shifter=state['shifter'])
+                for key, val in zip(('mu_vbuf_nmf', 'mv_vbuf_nmf'), _factorize_state(vt_buf, signed=False, shifter=state['shifter'])):
+                    state[key].copy_(val)
                 # Apply second momentum update (adaptive scaling)
                 if group['use_atan2']:
                     denom = vt_buf.sqrt_()
@@ -628,7 +630,8 @@ class AdaMuon_adv(torch.optim.Optimizer):
                 update_f32 = update.float()
                 vt_buf = _reconstruct_state((state['mu_vbuf_nmf'], state['mv_vbuf_nmf']), signed=False, shifter=state['shifter'])
                 vt_buf.mul_(beta2).addcmul_(update_f32.view(d1, d2), update_f32.view(d1, d2), value=1 - beta2)
-                state['mu_vbuf_nmf'], state['mv_vbuf_nmf'] = _factorize_state(vt_buf, signed=False, shifter=state['shifter'])
+                for key, val in zip(('mu_vbuf_nmf', 'mv_vbuf_nmf'), _factorize_state(vt_buf, signed=False, shifter=state['shifter'])):
+                    state[key].copy_(val)
                 # Apply second moment scaling
                 if group['use_atan2']:
                     denom = vt_buf.sqrt_().view(original_shape)

--- a/adv_optm/optim/AdamW_adv.py
+++ b/adv_optm/optim/AdamW_adv.py
@@ -363,7 +363,8 @@ class AdamW_adv(torch.optim.Optimizer):
                 vt.mul_(beta2).addcmul_(grad_reshaped, grad_reshaped, value=1.0 - beta2)
 
             # Factorize
-            state['mu_v_nmf'], state['mv_v_nmf'] = _factorize_state(vt, signed=False, shifter=state['shifter'])
+            for key, val in zip(('mu_v_nmf', 'mv_v_nmf'), _factorize_state(vt, signed=False, shifter=state['shifter'])):
+                state[key].copy_(val)
 
             if group['use_atan2']:
                 denom = vt.sqrt_()
@@ -384,7 +385,8 @@ class AdamW_adv(torch.optim.Optimizer):
                 mt.lerp_(grad_reshaped, 1.0 - beta1)
 
                 # Factorize
-                state['mu_m_nmf'], state['mv_m_nmf'], state['sign'] = _factorize_state(mt.clone(), signed=True, shifter=state['shifter'])
+                for key, val in zip(('mu_m_nmf', 'mv_m_nmf', 'sign'), _factorize_state(mt.clone(), signed=True, shifter=state['shifter'])):
+                    state[key].copy_(val)
 
                 update_mt = mt
 
@@ -428,7 +430,8 @@ class AdamW_adv(torch.optim.Optimizer):
                 exp_avg_sq.mul_(beta2).addcmul_(grad_vt, grad_vt, value=1.0 - beta2)
 
             if factored_2nd:
-                state['mu_v_nmf'], state['mv_v_nmf'] = _factorize_state(exp_avg_sq.view(d1, d2), signed=False, shifter=state['shifter'])
+                for key, val in zip(('mu_v_nmf', 'mv_v_nmf'), _factorize_state(exp_avg_sq.view(d1, d2), signed=False, shifter=state['shifter'])):
+                    state[key].copy_(val)
             else:
                 set_state(state, 'exp_avg_sq', exp_avg_sq, actual_precision, random_int_state_tensor, non_neg=True)
 

--- a/adv_optm/optim/AdamW_adv.py
+++ b/adv_optm/optim/AdamW_adv.py
@@ -186,10 +186,8 @@ class AdamW_adv(torch.optim.Optimizer):
             for device in devices:
                 param_update.set_seed(device)
 
-        # Initialize compiled function
-        self._compiled_step_parameter = None
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled function (by parameter shape)
+        self._compiled_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         """
@@ -321,7 +319,15 @@ class AdamW_adv(torch.optim.Optimizer):
                 random_int_state_tensor = param_update._get_random_int_for_sr(p)
             elif group['actual_state_precision'] == 'int8_sr':
                 random_int_state_tensor = param_update._get_random_int_for_8bit_sr(p)
-            step_param_fn = self._compiled_step_parameter
+            # Cache compiled function per-shape
+            cache_key = (p.shape, state.get('factored', False))
+            if cache_key not in self._compiled_step_fns:
+                self._compiled_step_fns[cache_key] = torch.compile(
+                    self._step_parameter,
+                    fullgraph=True,
+                    dynamic=False
+                )
+            step_param_fn = self._compiled_step_fns[cache_key]
         else:
             step_param_fn = self._step_parameter
 
@@ -468,9 +474,6 @@ class AdamW_adv(torch.optim.Optimizer):
             update.mul_(update_scaling)
 
         param_update.apply_parameter_update(self, p, group, update, group['lr'], random_int_tensor=random_int_tensor, wd_scaler=wd_scaler)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_step_parameter = torch.compile(self._step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def step(self, closure=None):

--- a/adv_optm/optim/Adopt_adv.py
+++ b/adv_optm/optim/Adopt_adv.py
@@ -380,7 +380,8 @@ class Adopt_adv(torch.optim.Optimizer):
             else:
                 vt.mul_(beta2).addcmul_(grad_reshaped, grad_reshaped, value=1.0 - beta2)
             # Factorize
-            state['mu_v_nmf'], state['mv_v_nmf'] = _factorize_state(vt, signed=False, shifter=state['shifter'])
+            for key, val in zip(('mu_v_nmf', 'mv_v_nmf'), _factorize_state(vt, signed=False, shifter=state['shifter'])):
+                state[key].copy_(val)
             del vt
 
             if self.use_atan2:
@@ -398,7 +399,8 @@ class Adopt_adv(torch.optim.Optimizer):
                 mt.lerp_(normalized_grad, 1.0 - beta1)
 
                 # Factorize
-                state['mu_m_nmf'], state['mv_m_nmf'], state['sign'] = _factorize_state(mt.clone(), signed=True, shifter=state['shifter'])
+                for key, val in zip(('mu_m_nmf', 'mv_m_nmf', 'sign'), _factorize_state(mt.clone(), signed=True, shifter=state['shifter'])):
+                    state[key].copy_(val)
 
                 update_mt = mt
 
@@ -465,7 +467,8 @@ class Adopt_adv(torch.optim.Optimizer):
                 vt.mul_(beta2).addcmul_(grad_vt, grad_vt, value=1 - beta2)
 
             if factored_2nd:
-                state['mu_v_nmf'], state['mv_v_nmf'] = _factorize_state(vt.view(d1, d2), signed=False, shifter=state['shifter'])
+                for key, val in zip(('mu_v_nmf', 'mv_v_nmf'), _factorize_state(vt.view(d1, d2), signed=False, shifter=state['shifter'])):
+                    state[key].copy_(val)
             else:
                 set_state(state, 'exp_avg_sq', vt, actual_precision, random_int_state_tensor, non_neg=True)
             del random_int_state_tensor

--- a/adv_optm/optim/Adopt_adv.py
+++ b/adv_optm/optim/Adopt_adv.py
@@ -189,9 +189,8 @@ class Adopt_adv(torch.optim.Optimizer):
             for device in devices:
                 param_update.set_seed(device)
 
-        self._compiled_step_parameter = None
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled function (by parameter shape)
+        self._compiled_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         """
@@ -331,7 +330,15 @@ class Adopt_adv(torch.optim.Optimizer):
                 random_int_state_tensor = param_update._get_random_int_for_sr(p)
             elif group['actual_state_precision'] == 'int8_sr':
                 random_int_state_tensor = param_update._get_random_int_for_8bit_sr(p)
-            step_param_fn = self._compiled_step_parameter
+            # Cache compiled function per-shape
+            cache_key = (p.shape, state.get('factored', False))
+            if cache_key not in self._compiled_step_fns:
+                self._compiled_step_fns[cache_key] = torch.compile(
+                    self._step_parameter,
+                    fullgraph=True,
+                    dynamic=False
+                )
+            step_param_fn = self._compiled_step_fns[cache_key]
         else:
             lr = group['lr']
             step_param_fn = self._step_parameter
@@ -472,9 +479,6 @@ class Adopt_adv(torch.optim.Optimizer):
 
         # Parameter Update
         param_update.apply_parameter_update(self, p, group, update, lr, random_int_tensor=random_int_tensor, wd_scaler=wd_scaler)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_step_parameter = torch.compile(self._step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def step(self, closure=None):

--- a/adv_optm/optim/Lion_adv.py
+++ b/adv_optm/optim/Lion_adv.py
@@ -119,10 +119,8 @@ class Lion_adv(torch.optim.Optimizer):
             for device in devices:
                 param_update.set_seed(device)
 
-        # Initialize compiled function
-        self._compiled_step_parameter = None
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled function (by parameter shape)
+        self._compiled_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         """
@@ -205,7 +203,15 @@ class Lion_adv(torch.optim.Optimizer):
             if group.get('stochastic_sign', False):
                 random_noise_tensor = param_update._get_random_noise_for_sso(p)
             lr = torch.as_tensor(lr)
-            step_param_fn = self._compiled_step_parameter
+            # Cache compiled function per-shape
+            cache_key = (p.shape, state.get('factored', False))
+            if cache_key not in self._compiled_step_fns:
+                self._compiled_step_fns[cache_key] = torch.compile(
+                    self._step_parameter,
+                    fullgraph=True,
+                    dynamic=False
+                )
+            step_param_fn = self._compiled_step_fns[cache_key]
         else:
             step_param_fn = self._step_parameter
 
@@ -277,9 +283,6 @@ class Lion_adv(torch.optim.Optimizer):
             update.mul_(lr)
 
         param_update.apply_parameter_update(self, p, group, update, lr, random_int_tensor=random_int_tensor)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_step_parameter = torch.compile(self._step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def step(self, closure: Optional[callable] = None):

--- a/adv_optm/optim/Muon_adv.py
+++ b/adv_optm/optim/Muon_adv.py
@@ -485,8 +485,9 @@ class Muon_adv(torch.optim.Optimizer):
                 # Standard momentum
                 update = mt_buf.clone()
 
-            # Factorize
-            state['mu_mbuf_nmf'], state['mv_mbuf_nmf'], state['sign_buf'] = _factorize_state(mt_buf, signed=True, shifter=state['shifter'])
+            # Compress new momentum and store factors
+            for key, val in zip(('mu_mbuf_nmf', 'mv_mbuf_nmf', 'sign_buf'), _factorize_state(mt_buf, signed=True, shifter=state['shifter'])):
+                state[key].copy_(val)
             del mt_buf
 
             # Orthogonalization step

--- a/adv_optm/optim/Muon_adv.py
+++ b/adv_optm/optim/Muon_adv.py
@@ -254,11 +254,9 @@ class Muon_adv(torch.optim.Optimizer):
             for device in devices:
                 param_update.set_seed(device)
 
-        # Initialize compiled function
-        self._compiled_muon_step_parameter = None
-        self._compiled_adam_step_parameter = None
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled functions (by parameter shape)
+        self._compiled_muon_step_fns = {}
+        self._compiled_adam_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         """
@@ -396,7 +394,15 @@ class Muon_adv(torch.optim.Optimizer):
             random_int_state_tensor = None
             if is_compiled:
                 step_size = torch.as_tensor(step_size)
-                adam_step_param = self._compiled_adam_step_parameter
+                # Cache compiled function per-shape
+                cache_key = (p.shape, state.get('factored', False))
+                if cache_key not in self._compiled_adam_step_fns:
+                    self._compiled_adam_step_fns[cache_key] = torch.compile(
+                        Muon_AuxAdam._adam_step_parameter,
+                        fullgraph=True,
+                        dynamic=False
+                    )
+                adam_step_param = self._compiled_adam_step_fns[cache_key]
                 
                 actual_precision = group.get('adam_actual_state_precision', 'auto')
                 random_int_state_tensor = random_int_tensor
@@ -415,7 +421,15 @@ class Muon_adv(torch.optim.Optimizer):
             random_G_sketch = None
             if is_compiled:
                 lr = torch.as_tensor(group['lr'])
-                muon_step_param = self._compiled_muon_step_parameter
+                # Cache compiled function per-shape
+                cache_key = (p.shape, state.get('factored', False))
+                if cache_key not in self._compiled_muon_step_fns:
+                    self._compiled_muon_step_fns[cache_key] = torch.compile(
+                        self._muon_step_parameter,
+                        fullgraph=True,
+                        dynamic=False
+                    )
+                muon_step_param = self._compiled_muon_step_fns[cache_key]
 
                 # Generate state SR random tensor when compiled
                 actual_precision = group['actual_state_precision']
@@ -432,10 +446,6 @@ class Muon_adv(torch.optim.Optimizer):
                 muon_step_param = self._muon_step_parameter
 
             muon_step_param(p, grad, state, group, lr, random_int_tensor, random_int_state_tensor, random_G_sketch)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_muon_step_parameter = torch.compile(self._muon_step_parameter, *args, **kwargs)
-        self._compiled_adam_step_parameter = torch.compile(Muon_AuxAdam._adam_step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def _muon_step_parameter(self, p, grad, state, group, lr, random_int_tensor, random_int_state_tensor, random_G_sketch):

--- a/adv_optm/optim/Prodigy_adv.py
+++ b/adv_optm/optim/Prodigy_adv.py
@@ -218,11 +218,8 @@ class Prodigy_adv(torch.optim.Optimizer):
             for device in devices:
                 param_update.set_seed(device)
 
-        # Initialize compiled function
-        self._compiled_step_parameter = None
-
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled function (by parameter shape)
+        self._compiled_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         """
@@ -364,7 +361,15 @@ class Prodigy_adv(torch.optim.Optimizer):
                 random_int_state_tensor = param_update._get_random_int_for_sr(p)
             elif group['actual_state_precision'] == 'int8_sr':
                 random_int_state_tensor = param_update._get_random_int_for_8bit_sr(p)
-            step_param_fn = self._compiled_step_parameter
+            # Cache compiled function per-shape
+            cache_key = (p.shape, state.get('factored', False))
+            if cache_key not in self._compiled_step_fns:
+                self._compiled_step_fns[cache_key] = torch.compile(
+                    self._step_parameter,
+                    fullgraph=True,
+                    dynamic=False
+                )
+            step_param_fn = self._compiled_step_fns[cache_key]
         else:
             d = group['d']
             step_param_fn = self._step_parameter
@@ -521,9 +526,6 @@ class Prodigy_adv(torch.optim.Optimizer):
                 del state['p0']
 
         param_update.apply_parameter_update(self, p, group, update, dlr, random_int_tensor=random_int_tensor, wd_scaler=wd_scaler)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_step_parameter = torch.compile(self._step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def step(self, closure=None):

--- a/adv_optm/optim/Prodigy_adv.py
+++ b/adv_optm/optim/Prodigy_adv.py
@@ -405,7 +405,8 @@ class Prodigy_adv(torch.optim.Optimizer):
                 mt.mul_(self.beta1).add_(grad_reshaped, alpha=d * (1.0 - self.beta1))
 
                 # Factorize
-                state['mu_m_nmf'], state['mv_m_nmf'], state['sign'] = _factorize_state(mt.clone(), signed=True, shifter=state['shifter'])
+                for key, val in zip(('mu_m_nmf', 'mv_m_nmf', 'sign'), _factorize_state(mt.clone(), signed=True, shifter=state['shifter'])):
+                    state[key].copy_(val)
 
                 update_mt = mt
 
@@ -426,7 +427,8 @@ class Prodigy_adv(torch.optim.Optimizer):
                 update = grad_reshaped.mul(d)
 
             # Factorize
-            state['mu_v_nmf'], state['mv_v_nmf'] = _factorize_state(vt, signed=False, shifter=state['shifter'])
+            for key, val in zip(('mu_v_nmf', 'mv_v_nmf'), _factorize_state(vt, signed=False, shifter=state['shifter'])):
+                state[key].copy_(val)
 
             if group['use_atan2']:
                 denom = vt.sqrt_()
@@ -478,7 +480,8 @@ class Prodigy_adv(torch.optim.Optimizer):
                 exp_avg_sq.mul_(beta2).addcmul_(grad_vt, grad_vt, value=d * d * (1.0 - beta2))
 
             if factored_2nd:
-                state['mu_v_nmf'], state['mv_v_nmf'] = _factorize_state(exp_avg_sq.view(d1, d2), signed=False, shifter=state['shifter'])
+                for key, val in zip(('mu_v_nmf', 'mv_v_nmf'), _factorize_state(exp_avg_sq.view(d1, d2), signed=False, shifter=state['shifter'])):
+                    state[key].copy_(val)
             else:
                 set_state(state, 'exp_avg_sq', exp_avg_sq, actual_precision, random_int_state_tensor, non_neg=True)
             del random_int_state_tensor

--- a/adv_optm/optim/SignSGD_adv.py
+++ b/adv_optm/optim/SignSGD_adv.py
@@ -136,10 +136,8 @@ class SignSGD_adv(torch.optim.Optimizer):
             for device in devices:
                 param_update.set_seed(device)
 
-        # Initialize compiled function
-        self._compiled_step_parameter = None
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled function (by parameter shape)
+        self._compiled_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         """
@@ -237,7 +235,16 @@ class SignSGD_adv(torch.optim.Optimizer):
                 random_noise_tensor = param_update._get_random_noise_for_sso(p)
 
             lr = torch.as_tensor(lr)
-            step_param_fn = self._compiled_step_parameter
+
+            # Cache compiled function per-shape
+            cache_key = (p.shape, state.get('factored', False))
+            if cache_key not in self._compiled_step_fns:
+                self._compiled_step_fns[cache_key] = torch.compile(
+                    self._step_parameter,
+                    fullgraph=True,
+                    dynamic=False
+                )
+            step_param_fn = self._compiled_step_fns[cache_key]
         else:
             step_param_fn = self._step_parameter
 
@@ -357,9 +364,6 @@ class SignSGD_adv(torch.optim.Optimizer):
             update.mul_(update_scaling)
 
         param_update.apply_parameter_update(self, p, group, update, lr, random_int_tensor=random_int_tensor, wd_target=wd_target, cwd_target=cwd_target)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_step_parameter = torch.compile(self._step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def step(self, closure: Optional[callable] = None):

--- a/adv_optm/optim/SignSGD_adv.py
+++ b/adv_optm/optim/SignSGD_adv.py
@@ -304,7 +304,8 @@ class SignSGD_adv(torch.optim.Optimizer):
                     raw_update = exp_avg.clone()
 
                 # Compress new momentum m_t and store factors
-                state['mu_m_nmf'], state['mv_m_nmf'], state['sign'] = _factorize_state(exp_avg, signed=True, shifter=state['shifter'])
+                for key, val in zip(('mu_m_nmf', 'mv_m_nmf', 'sign'), _factorize_state(exp_avg, signed=True, shifter=state['shifter'])):
+                    state[key].copy_(val)
             else:
                 raw_update = grad_reshaped.clone()
 

--- a/adv_optm/optim/SinkSGD_adv.py
+++ b/adv_optm/optim/SinkSGD_adv.py
@@ -124,9 +124,8 @@ class SinkSGD_adv(torch.optim.Optimizer):
 
         self.init_step()
 
-        self._compiled_step_parameter = None
-        if compiled_optimizer:
-            self.compile(fullgraph=True)
+        # Initialize compiled function (by parameter shape)
+        self._compiled_step_fns = {}
 
     def load_state_dict(self, state_dict: dict) -> None:
         super().load_state_dict(state_dict)
@@ -210,7 +209,15 @@ class SinkSGD_adv(torch.optim.Optimizer):
                 random_int_state_tensor = param_update._get_random_int_for_sr(p)
             elif group['actual_state_precision'] == 'int8_sr':
                 random_int_state_tensor = param_update._get_random_int_for_8bit_sr(p)
-            step_param_fn = self._compiled_step_parameter
+            # Cache compiled function per-shape
+            cache_key = (p.shape, state.get('factored', False))
+            if cache_key not in self._compiled_step_fns:
+                self._compiled_step_fns[cache_key] = torch.compile(
+                    self._step_parameter,
+                    fullgraph=True,
+                    dynamic=False
+                )
+            step_param_fn = self._compiled_step_fns[cache_key]
         else:
             step_param_fn = self._step_parameter
 
@@ -360,9 +367,6 @@ class SinkSGD_adv(torch.optim.Optimizer):
             update.mul_(update_scaling)
 
         param_update.apply_parameter_update(self, p, group, update, step_size, random_int_tensor=random_int_tensor, wd_scaler=wd_scaler, wd_target=wd_target, cwd_target=cwd_target)
-
-    def compile(self, *args, **kwargs):
-        self._compiled_step_parameter = torch.compile(self._step_parameter, *args, **kwargs)
 
     @torch.no_grad()
     def step(self, closure=None):

--- a/adv_optm/optim/SinkSGD_adv.py
+++ b/adv_optm/optim/SinkSGD_adv.py
@@ -277,9 +277,6 @@ class SinkSGD_adv(torch.optim.Optimizer):
 
                 buf.lerp_(grad_reshaped, 1 - momentum)
 
-                # Factorize updated buffer
-                state['mu_b_nmf'], state['mv_b_nmf'], state['sign'] = _factorize_state(buf.clone(), signed=True, shifter=state['shifter'])
-
                 if nesterov:
                     nv_coef = momentum if nesterov_coef is None else nesterov_coef
                     if normed_mt:
@@ -288,6 +285,11 @@ class SinkSGD_adv(torch.optim.Optimizer):
                         update = grad_reshaped.lerp(buf, nv_coef)
                 else:
                     update = buf.clone()
+
+                # Factorize updated buffer
+                for key, val in zip(('mu_b_nmf', 'mv_b_nmf', 'sign'), _factorize_state(buf, signed=True, shifter=state['shifter'])):
+                    state[key].copy_(val)
+
             else:
                 update = grad_reshaped.clone()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="adv_optm",
-    version="2.5.8",
+    version="2.5.9",
     author="Koratahiu",
     author_email="hiuhonor@gmail.com",
     license='Apache 2.0',


### PR DESCRIPTION
This PR addresses an issue where `torch.compile` stalls during the compilation of the optimizer in factored mode. 

When using the compiled optimizer with factored states, SymPy can experience an expression explosion. This leads to highly nested symbolic representations that stall the compilation process. 
An example of the generated expressions:
```python
960*(((((307200//s22))*((s22//320))*(((s42*((s22//320)))//120)))//960))
```

This behavior appears to be a regression, as it was not observed in earlier PyTorch versions (such as 2.7/2.9).

### Solution

To mitigate this issue, this PR changes the compilation strategy to compile **per-shape** instead of compiling a single universal function for the entire optimizer. We implement this by caching and creating a separate compiled function for each unique parameter shape. 

### Toy Benchmark

A simple toy benchmark comparing the different strategies across various state precisions:

| State Precision | Compile Strategy | Compile Time | Step Time | Peak VRAM |
| :--- | :--- | ---: | ---: | ---: |
| fp32 | Eager Mode (No Compile) | 0.24 s | 11.75 ms | 186.2 MB |
| fp32 | Standard Compile (Global, Dynamic) | 3.99 s | 10.99 ms | 178.2 MB |
| fp32 | Shaped Compile (Per-Shape) | 1.40 s | 3.89 ms | 162.2 MB |
| int8_sr | Eager Mode (No Compile) | 0.02 s | 16.48 ms | 202.4 MB |
| int8_sr | Standard Compile (Global, Dynamic) | 17.03 s | 11.48 ms | 138.5 MB |
| int8_sr | Shaped Compile (Per-Shape) | 1.60 s | 4.41 ms | 154.5 MB |
| factored | Eager Mode (No Compile) | 0.04 s | 15.62 ms | 151.4 MB |
| factored | Shaped Compile (Per-Shape) | 2.01 s | 3.99 ms | 97.2 MB |

In addition to resolving the SymPy stalling issue, the benchmark indicates that the per-shape compilation strategy may provide notable improvements in both compile times and step execution times. This is likely because the compiler can generate more specialized kernels for specific shapes rather than attempting to generalize across a wide range of dynamic dimensions.
I also tested it for SDXL full fine-tuning and it was ~25% faster.